### PR TITLE
Fix initial display of final split amounts

### DIFF
--- a/script.js
+++ b/script.js
@@ -96,6 +96,7 @@ document.addEventListener("DOMContentLoaded", () => {
             this.elements.setBillBtn.disabled = true;
             this.elements.paymentSection.classList.remove("hidden");
             this.updateRemaining();
+            this.updateFinalSplit();
         }
 
         submitPayment() {


### PR DESCRIPTION
## Summary
- ensure the "Final Split" table is populated as soon as the bill is set

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6842aed568a8832c9d5cf3c125162f9d