### PR TITLE
Add delete and undo/redo controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,8 @@
                 <div class="person-list" id="personList"></div>
                 <button id="submitPayment">Record Payment</button>
                 <p id="errorMessage" class="error"></p>
+                <button id="undoAction">Undo</button>
+                <button id="redoAction">Redo</button>
                 <button id="resetAll">Reset All</button>
             </div>
         </div>
@@ -38,6 +40,7 @@
                     <tr>
                         <th>Amount (€)</th>
                         <th>People</th>
+                        <th>Actions</th>
                     </tr>
                 </thead>
                 <tbody></tbody>

--- a/script.js
+++ b/script.js
@@ -19,11 +19,16 @@ document.addEventListener("DOMContentLoaded", () => {
                 errorMessage: document.getElementById("errorMessage"),
                 remainingDisplay: document.getElementById("remainingAmount"),
                 resetBtn: document.getElementById("resetAll"),
+                undoBtn: document.getElementById("undoAction"),
+                redoBtn: document.getElementById("redoAction"),
                 transactionTable: document.getElementById("transactionTable").querySelector("tbody"),
                 finalTable: document.getElementById("finalTable").querySelector("tbody"),
                 paymentSection: document.getElementById("paymentSection"),
                 dateTimeDisplay: document.getElementById("currentDateTime")
             };
+
+            this.undoStack = [];
+            this.redoStack = [];
 
             this.initialize();
             this.updateDateTime();
@@ -33,6 +38,7 @@ document.addEventListener("DOMContentLoaded", () => {
             this.state.people.forEach(person => this.state.payments[person] = 0);
             this.renderPeople();
             this.addEventListeners();
+            this.renderAll();
         }
 
         renderPeople() {
@@ -49,6 +55,45 @@ document.addEventListener("DOMContentLoaded", () => {
             return `€${parseFloat(amount).toFixed(2)}`;
         }
 
+        pushState() {
+            this.undoStack.push(JSON.parse(JSON.stringify(this.state)));
+            this.redoStack = [];
+        }
+
+        recalcFromTransactions() {
+            this.state.remainingAmount = this.state.billAmount;
+            this.state.people.forEach(p => this.state.payments[p] = 0);
+            this.state.transactions.forEach(t => {
+                const amount = parseFloat(t.amount.replace('€',''));
+                const people = t.people.split(', ').filter(Boolean);
+                this.state.remainingAmount -= amount;
+                const per = amount / people.length;
+                people.forEach(person => {
+                    if (this.state.payments[person] === undefined) {
+                        this.state.payments[person] = 0;
+                    }
+                    this.state.payments[person] += per;
+                });
+            });
+        }
+
+        renderAll() {
+            this.elements.billInput.value = this.state.billAmount || '';
+            const billSet = this.state.billAmount > 0;
+            this.elements.billInput.disabled = billSet;
+            this.elements.setBillBtn.disabled = billSet;
+            if (billSet) {
+                this.elements.paymentSection.classList.remove('hidden');
+            } else {
+                this.elements.paymentSection.classList.add('hidden');
+            }
+            this.updateRemaining();
+            this.updateTransactions();
+            this.updateFinalSplit();
+            this.elements.undoBtn.disabled = this.undoStack.length === 0;
+            this.elements.redoBtn.disabled = this.redoStack.length === 0;
+        }
+
         updateDateTime() {
             this.elements.dateTimeDisplay.textContent = new Date().toLocaleString();
             setInterval(() => {
@@ -61,12 +106,20 @@ document.addEventListener("DOMContentLoaded", () => {
         }
 
         updateTransactions() {
-            this.elements.transactionTable.innerHTML = this.state.transactions.map(t => `
+            this.elements.transactionTable.innerHTML = this.state.transactions.map((t, i) => `
                 <tr>
                     <td>${t.amount}</td>
                     <td>${t.people}</td>
+                    <td><button class="delete-btn" data-index="${i}" aria-label="Delete transaction">✕</button></td>
                 </tr>
             `).join("");
+
+            this.elements.transactionTable.querySelectorAll('.delete-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const idx = parseInt(btn.getAttribute('data-index'));
+                    this.deleteTransaction(idx);
+                });
+            });
         }
 
         updateFinalSplit() {
@@ -87,6 +140,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 return;
             }
 
+            this.pushState();
             this.state.billAmount = amount;
             this.state.remainingAmount = amount;
             this.elements.billMessage.textContent = `Bill set to: ${this.formatCurrency(amount)}`;
@@ -95,8 +149,7 @@ document.addEventListener("DOMContentLoaded", () => {
             this.elements.billInput.disabled = true;
             this.elements.setBillBtn.disabled = true;
             this.elements.paymentSection.classList.remove("hidden");
-            this.updateRemaining();
-            this.updateFinalSplit();
+            this.renderAll();
         }
 
         submitPayment() {
@@ -119,6 +172,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 return;
             }
 
+            this.pushState();
             this.state.remainingAmount -= amount;
             const people = selected.length ? selected : this.state.people;
             const perPerson = amount / people.length;
@@ -132,10 +186,29 @@ document.addEventListener("DOMContentLoaded", () => {
             this.elements.errorMessage.textContent = "";
             this.elements.paidInput.value = "";
             this.elements.personList.querySelectorAll(".person").forEach(btn => btn.classList.remove("selected"));
-            
-            this.updateRemaining();
-            this.updateTransactions();
-            this.updateFinalSplit();
+
+            this.renderAll();
+        }
+
+        deleteTransaction(index) {
+            this.pushState();
+            this.state.transactions.splice(index, 1);
+            this.recalcFromTransactions();
+            this.renderAll();
+        }
+
+        undo() {
+            if (this.undoStack.length === 0) return;
+            this.redoStack.push(JSON.parse(JSON.stringify(this.state)));
+            this.state = this.undoStack.pop();
+            this.renderAll();
+        }
+
+        redo() {
+            if (this.redoStack.length === 0) return;
+            this.undoStack.push(JSON.parse(JSON.stringify(this.state)));
+            this.state = this.redoStack.pop();
+            this.renderAll();
         }
 
         reset() {
@@ -153,6 +226,8 @@ document.addEventListener("DOMContentLoaded", () => {
             });
             this.elements.submitBtn.addEventListener("click", () => this.submitPayment());
             this.elements.resetBtn.addEventListener("click", () => this.reset());
+            this.elements.undoBtn.addEventListener("click", () => this.undo());
+            this.elements.redoBtn.addEventListener("click", () => this.redo());
         }
     }
 

--- a/styles.css
+++ b/styles.css
@@ -143,6 +143,17 @@ th {
     display: none;
 }
 
+.delete-btn {
+    background: #e74c3c;
+    padding: 4px 8px;
+    font-weight: bold;
+}
+
+#undoAction,
+#redoAction {
+    background: #95a5a6;
+}
+
 @media (max-width: 768px) {
     .container {
         grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- add Undo/Redo buttons and Actions column to HTML
- style delete/undo/redo buttons
- implement undo/redo stacks
- implement delete transaction action
- recalc state from transactions
- use an `✕` button in each transaction row

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842b597a528832c81ff9cd6b890d498